### PR TITLE
fix(error-boundary): log errors with err serializer

### DIFF
--- a/src/components/shared/errors/ErrorBoundary.tsx
+++ b/src/components/shared/errors/ErrorBoundary.tsx
@@ -23,7 +23,7 @@ class ErrorBoundary extends Component<PropsWithChildren, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    logger.error({ error, errorInfo });
+    logger.error({ err: error, errorInfo });
   }
 
   render(): ReactNode {


### PR DESCRIPTION
## Beskrivelse

Fikser ErrorBoundary-loggingen slik at `Error`-objekter logges under `err` og serialiseres korrekt av pino/next-logger.

## Endringer

- `src/components/shared/errors/ErrorBoundary.tsx`: endret logging-kallet fra `logger.error({ error, errorInfo })` til `logger.error({ err: error, errorInfo })`

## Issue

Closes #672

## Verifisering

- `pnpm exec biome check src/components/shared/errors/ErrorBoundary.tsx`
- `pnpm exec tsc --noEmit` *(feiler i eksisterende repo-/arbeidstreetilstand, se kommentar under)*

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
