### PR TITLE
fix(docs): oppdater lenke til varsling på SMS og e-post

### DIFF
--- a/src/docs/sporsmal-og-svar.mdx
+++ b/src/docs/sporsmal-og-svar.mdx
@@ -38,7 +38,7 @@
 <SporsmalOgSvarWrapper>
     ## Hvordan kan jeg styre hvilke varsler jeg får på SMS og e-post?
 
-    Noen av varslene kan du velge om du vil ha, og du kan bestemme hvilken adresse de skal komme til. Les mer her: [Hvordan styre varsel på SMS og e-post](https://www.nav.no/no/bedrift/oppfolging/sykmeldt-arbeidstaker/digital-sykmelding-informasjon-til-arbeidsgivere/hvordan-styre-varsel-pa%CC%8A-sms-og-e-post).
+    Noen av varslene kan du velge om du vil ha, og du kan bestemme hvilken adresse de skal komme til. Les mer her: [Hvordan styre varsel på SMS og e-post](https://www.nav.no/arbeidsgiver/tilganger#varsling).
 
 </SporsmalOgSvarWrapper>
 


### PR DESCRIPTION
## Beskrivelse

Oppdaterer FAQ-lenken for varsling på SMS og e-post, slik at den peker til gjeldende side for arbeidsgivere på nav.no.

Verifisert med `pnpm run build`, `pnpm run test` og `pnpm run lint` (lint kjørte grønt med 7 eksisterende warnings).

## Endringer

- `src/docs/sporsmal-og-svar.mdx`: byttet ut utdatert lenke til informasjon om varsling på SMS og e-post

## Issue

Ingen issue koblet.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
