### PR TITLE
fix: replace deprecated link to sykefravarsstatistikk

### DIFF
--- a/src/components/NarmestelederInfo/NarmestelederInfo.tsx
+++ b/src/components/NarmestelederInfo/NarmestelederInfo.tsx
@@ -68,7 +68,7 @@ function NarmestelederInfo(): ReactElement {
             <div>
               <LinkPanel
                 Icon={BarChartIcon}
-                href="https://arbeidsgiver.nav.no/sykefravarsstatistikk/"
+                href="https://arbeidsgiver.nav.no/forebygge-fravar/sykefravarsstatistikk"
                 description="Utforsk potensialet i din virksomhet ved å sammenligne den med andre i din næring."
                 external="absolute"
               >


### PR DESCRIPTION
## Beskrivelse

<!-- Hva gjør denne PR-en og hvorfor? -->
Oppdaterer lenken til sykefraværsstatistikk. Bakgrunn: `Team Pia har endret URL-strukturen til sidene om forebygging av fravær. Redirect som benyttes i dag vil bli fjernet snart`

## Endringer

<!-- - `fil/modul`: Hva som ble endret -->
* `NarmestelederInfo.tsx`: Endrer lenken

## Issue

Closes #715

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
